### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/chatbot/stock.py
+++ b/chatbot/stock.py
@@ -1,7 +1,7 @@
 import json
 from typing import Dict
 
-from fuzzywuzzy import process
+from rapidfuzz import process
 from yahoo_fin.stock_info import get_live_price
 
 from chatbot.util import output

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ cssselect==1.1.0
 cycler==0.10.0
 cymem==2.0.2
 fake-useragent==0.1.11
-fuzzywuzzy==0.17.0
 gast==0.3.2
 geographiclib==1.49
 geopy==1.20.0
@@ -43,9 +42,9 @@ pyparsing==2.4.2
 pyppeteer==0.0.25
 pyquery==1.4.0
 python-dateutil==2.8.0
-python-Levenshtein==0.12.0
 pytz==2019.2
 PyYAML==5.1.2
+rapidfuzz==0.6.3
 requests==2.22.0
 requests-html==0.10.0
 scikit-learn==0.21.3


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is [faster](https://github.com/rhasspy/rapidfuzz/blob/master/Benchmarks.md) than FuzzyWuzzy